### PR TITLE
Give each instance of ButtonToButtonsLongPress a unique longPressTimer

### DIFF
--- a/ButtonToButtonsLongPress/ButtonToButtonsLongPress.cs
+++ b/ButtonToButtonsLongPress/ButtonToButtonsLongPress.cs
@@ -25,7 +25,7 @@ namespace ButtonToButtonsLongPress
         public int ShortPressDuration { get; set; }
 
         private bool _longHeld;
-        private static Timer _longPressTimer;
+        private Timer _longPressTimer;
 
         public ButtonToButtonsLongPress()
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Deprecated
 ### Removed
 ### Fixed
+- Each instance of ButtonToButtonsLongPress needs their own/private longPressTimer 
 
 ## [0.0.2] - 2018-10-29
 ### Added


### PR DESCRIPTION
There was an issue where only the last instance of ButtonToButtonsLongPress was working du to all instance sharing the same longPressTimer.
