### PR TITLE
Add AxisSplitter with Enable and Buttons to Rotary selection

### DIFF
--- a/AxisSplitterWithEnable/AxisSplitterEnable.cs
+++ b/AxisSplitterWithEnable/AxisSplitterEnable.cs
@@ -1,0 +1,90 @@
+﻿using System.Reflection;
+using HidWizards.UCR.Core.Attributes;
+using HidWizards.UCR.Core.Models;
+using HidWizards.UCR.Core.Models.Binding;
+using HidWizards.UCR.Core.Utilities;
+using HidWizards.UCR.Core.Utilities.AxisHelpers;
+
+namespace HidWizards.UCR.Plugins.Remapper
+{
+    [Plugin("Axis Splitter with Enable", Group = "Axis", Description = "Split one axis into two new axes, when disabled ressets axes to default values")]
+    [PluginInput(DeviceBindingCategory.Range, "Axis")]
+    [PluginInput(DeviceBindingCategory.Momentary, "Enable")]
+    [PluginOutput(DeviceBindingCategory.Range, "Axis high")]
+    [PluginOutput(DeviceBindingCategory.Range, "Axis low")]
+    public class AxisSplitterEnable : Plugin
+    {
+        [PluginGui("Invert Enable", Order = 1)]
+        public bool InvertEnable { get; set; }
+
+
+        [PluginGui("Invert high", Order = 2)]
+        public bool InvertHigh { get; set; }
+
+        [PluginGui("Default high", Order = 3)]
+        public double DefaultHigh { get; set; }
+
+
+        [PluginGui("Invert low", Order = 4)]
+        public bool InvertLow { get; set; }
+        
+        [PluginGui("Default high", Order = 5)]
+        public double DefaultLow { get; set; }
+
+
+        [PluginGui("Dead zone")]
+        public int DeadZone { get; set; }
+
+        private readonly DeadZoneHelper _deadZoneHelper = new DeadZoneHelper();
+
+        public AxisSplitterEnable()
+        {
+            DeadZone = 0;
+            DefaultLow = 0;
+            DefaultHigh = 0;
+        }
+
+        public override void InitializeCacheValues()
+        {
+            Initialize();
+        }
+
+        public override void Update(params short[] values)
+        {
+            var value = values[0];
+            var enable = values[1];
+            var high = Functions.GetRangeFromPercentage((short)DefaultHigh);
+            var low = Functions.GetRangeFromPercentage((short)DefaultLow);
+            if (enable > 0 ^ InvertEnable)
+            {
+                if (DeadZone != 0) value = _deadZoneHelper.ApplyRangeDeadZone(value);
+                high = Functions.SplitAxis(value, true);
+                low = Functions.SplitAxis(value, false);
+                if (InvertHigh) high = Functions.Invert(high);
+                if (InvertLow) low = Functions.Invert(low);
+            }
+
+            WriteOutput(0, high);
+            WriteOutput(1, low);
+        }
+
+        private void Initialize()
+        {
+            _deadZoneHelper.Percentage = DeadZone;
+        }
+
+        public override PropertyValidationResult Validate(PropertyInfo propertyInfo, dynamic value)
+        {
+            switch (propertyInfo.Name)
+            {
+                case nameof(DeadZone):
+                    return InputValidation.ValidatePercentage(value);
+                case nameof(DefaultLow):
+                case nameof(DefaultHigh):
+                    return InputValidation.ValidateRange(value, -100.0, 100.0);
+            }
+
+            return PropertyValidationResult.ValidResult;
+        }
+    }
+}

--- a/AxisSplitterWithEnable/AxisSplitterEnable.csproj
+++ b/AxisSplitterWithEnable/AxisSplitterEnable.csproj
@@ -4,15 +4,14 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{932CF336-0564-4E33-9433-375CB98C9886}</ProjectGuid>
+    <ProjectGuid>{9DD53770-1747-47D0-A1FE-22822911CA7C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DeltaToButtons</RootNamespace>
-    <AssemblyName>DeltaToButtons</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RootNamespace>AxisSplitterEnable</RootNamespace>
+    <AssemblyName>AxisSplitterEnable</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -40,12 +39,13 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UCR.Core">
+    <Reference Include="UCR.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\_Build\UCR.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DeltaToButtons.cs" />
+    <Compile Include="AxisSplitterEnable.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -56,6 +56,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(ProjectName).dll" "$(SolutionDir)UCR.Plugins"</PostBuildEvent>
+    <PostBuildEvent>xcopy /y "$(TargetDir)$(ProjectName).dll" "$(SolutionDir)UCR.Plugins"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/AxisSplitterWithEnable/Properties/AssemblyInfo.cs
+++ b/AxisSplitterWithEnable/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AxisSplitterEnable")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AxisSplitterEnable")]
+[assembly: AssemblyCopyright("Copyright Lupus the Canine ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bc6cf2c8-cc80-4eae-9ae2-8d23f4e744de")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/EventToButton/EventToButton.csproj
+++ b/EventToButton/EventToButton.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EventToButton</RootNamespace>
     <AssemblyName>EventToButton</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/RotaryRocker/Properties/AssemblyInfo.cs
+++ b/RotaryRocker/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Ogólne informacje o zestawie są kontrolowane poprzez następujący 
+// zestaw atrybutów. Zmień wartości tych atrybutów, aby zmodyfikować informacje
+// powiązane z zestawem.
+[assembly: AssemblyTitle("RotaryRocker")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RotaryRocker")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Ustawienie elementu ComVisible na wartość false sprawia, że typy w tym zestawie są niewidoczne
+// dla składników COM. Jeśli potrzebny jest dostęp do typu w tym zestawie z
+// COM, ustaw wartość true dla atrybutu ComVisible tego typu.
+[assembly: ComVisible(false)]
+
+// Następujący identyfikator GUID jest identyfikatorem biblioteki typów w przypadku udostępnienia tego projektu w modelu COM
+[assembly: Guid("d38fc579-62c3-4ca6-bd41-4c8c2875e118")]
+
+// Informacje o wersji zestawu zawierają następujące cztery wartości:
+//
+//      Wersja główna
+//      Wersja pomocnicza
+//      Numer kompilacji
+//      Poprawka
+//
+// Możesz określić wszystkie wartości lub użyć domyślnych numerów kompilacji i poprawki
+// przy użyciu symbolu „*”, tak jak pokazano poniżej:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/RotaryRocker/RotaryRocker.cs
+++ b/RotaryRocker/RotaryRocker.cs
@@ -1,0 +1,108 @@
+﻿using System.Reflection;
+using HidWizards.UCR.Core.Attributes;
+using HidWizards.UCR.Core.Models;
+using HidWizards.UCR.Core.Models.Binding;
+using HidWizards.UCR.Core.Utilities;
+using System.Threading;
+
+
+namespace HidWizards.UCR.Plugins.Remapper
+{
+    [Plugin("Rotary/Rocker", Group = "Button", Description = "Two buttons into rotary or multiposition switch")]
+    [PluginInput(DeviceBindingCategory.Momentary , "Up")]
+    [PluginInput(DeviceBindingCategory.Momentary, "Down")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "1")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "2")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "3")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "4")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "5")]
+    [PluginOutput(DeviceBindingCategory.Momentary, "6")]
+    
+    public class RotaryRocker : Plugin
+    {
+        [PluginGui("Rotary", Order = 1)]
+        public bool Rotary { get; set; }
+
+
+        [PluginGui("Position Count", Order = 2)]
+        public int PositionCount { get; set; }
+
+        [PluginGui("Hold", Order = 3)]
+        public bool Hold { get; set; }
+
+        public RotaryRocker()
+        {
+            Rotary = false;
+            PositionCount = 5;
+            Hold = true;
+        }
+        private bool pUp = false;
+
+        private bool pDown = false;
+        private int position = 0;
+        public override void InitializeCacheValues()
+        {
+            Initialize();
+        }
+
+        public override void Update(params short[] values)
+        {
+            var up =  values[0]>0;
+            var down = values[1]>0;
+            if (up&&!pUp)
+            {
+                WriteOutput(position, 0);
+                position++;
+                if (position >= PositionCount)
+                {
+                    position = Rotary ? 0 : PositionCount - 1;
+                }
+                WriteOutput(position, 1);
+                if (!Hold)
+                {
+                    Thread.Sleep(50);
+                    WriteOutput(position, 0);
+                }
+            }
+            pUp = up;
+
+            if (down&&!pDown)
+            {
+                WriteOutput(position, 0);
+                position--;
+                if (position <0)
+                {
+                    position = Rotary ? PositionCount - 1 : 0;
+                }
+                WriteOutput(position, 1);
+                if(!Hold)
+                {
+                    Thread.Sleep(50);
+                    WriteOutput(position, 0);
+                }
+            }
+            pDown = down;
+        }
+
+        private void Initialize()
+        {
+            WriteOutput(position, Hold ? (short)1 : (short)0);
+        }
+
+        public override PropertyValidationResult Validate(PropertyInfo propertyInfo, dynamic value)
+        {
+            switch (propertyInfo.Name)
+            {
+                case nameof(PositionCount):
+                    return InputValidation.ValidateRange(value, 1, 6);
+            }
+
+            return PropertyValidationResult.ValidResult;
+        }
+        public override void OnActivate()
+        {
+            base.OnActivate();
+            WriteOutput(position, Hold?(short)1:(short)0);
+        }
+    }
+}

--- a/RotaryRocker/RotaryRocker.csproj
+++ b/RotaryRocker/RotaryRocker.csproj
@@ -4,15 +4,14 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{932CF336-0564-4E33-9433-375CB98C9886}</ProjectGuid>
+    <ProjectGuid>{D38FC579-62C3-4CA6-BD41-4C8C2875E118}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>DeltaToButtons</RootNamespace>
-    <AssemblyName>DeltaToButtons</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <RootNamespace>RotaryRocker</RootNamespace>
+    <AssemblyName>RotaryRocker</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,17 +44,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DeltaToButtons.cs" />
+    <Compile Include="RotaryRocker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\_Build\_Build.csproj">
-      <Project>{3b55d2da-ab7b-461d-ab16-9d1f16b65c32}</Project>
-      <Name>_Build</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(ProjectName).dll" "$(SolutionDir)UCR.Plugins"</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/UCR-Plugins.sln
+++ b/UCR-Plugins.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2019
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30406.217
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AxesToAxesTrim", "AxesToAxesTrim\AxesToAxesTrim.csproj", "{B4989441-115E-47E2-BF89-4E02A426E5A5}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -44,6 +44,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReversibleThrottle", "ReversibleThrottle\ReversibleThrottle.csproj", "{35C07F51-FF2F-4D34-BA20-FA45120EF58F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FpvAngleMix", "FpvAngleMix\FpvAngleMix.csproj", "{B234EAE9-D26E-49F4-9EE7-7E44C4A319BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AxisSplitterEnable", "AxisSplitterWithEnable\AxisSplitterEnable.csproj", "{9DD53770-1747-47D0-A1FE-22822911CA7C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RotaryRocker", "RotaryRocker\RotaryRocker.csproj", "{D38FC579-62C3-4CA6-BD41-4C8C2875E118}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -99,6 +103,14 @@ Global
 		{B234EAE9-D26E-49F4-9EE7-7E44C4A319BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B234EAE9-D26E-49F4-9EE7-7E44C4A319BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B234EAE9-D26E-49F4-9EE7-7E44C4A319BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DD53770-1747-47D0-A1FE-22822911CA7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DD53770-1747-47D0-A1FE-22822911CA7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DD53770-1747-47D0-A1FE-22822911CA7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DD53770-1747-47D0-A1FE-22822911CA7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D38FC579-62C3-4CA6-BD41-4C8C2875E118}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D38FC579-62C3-4CA6-BD41-4C8C2875E118}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D38FC579-62C3-4CA6-BD41-4C8C2875E118}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D38FC579-62C3-4CA6-BD41-4C8C2875E118}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds modified Axis Splitter that sets output to default values when enable button is not pressed.

Adds Buttons to Rotary selection. Turns two buttons into rotary selection with up to 6 positions with or without rollover. Would it be possible to separate input and output so user can easily add more buttons to the setup?